### PR TITLE
feat(ci): Add auto-triage GitHub Action

### DIFF
--- a/.github/workflows/auto-triage-feedback.yml
+++ b/.github/workflows/auto-triage-feedback.yml
@@ -1,0 +1,89 @@
+name: Auto Triage User Feedback
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  triage:
+    # user-feedbackラベルが付いたIssueのみ処理
+    if: contains(github.event.issue.labels.*.name, 'user-feedback')
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Claude Code Triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            あなたはPokemon Battle Factory計算機のフィードバックをトリアージするアシスタントです。
+
+            **Issue情報:**
+            - Repository: ${{ github.repository }}
+            - Issue #${{ github.event.issue.number }}
+            - Title: ${{ github.event.issue.title }}
+            - Author: ${{ github.event.issue.user.login }}
+
+            **Issue内容:**
+            ${{ github.event.issue.body }}
+
+            ---
+
+            このフィードバックを以下の3つのカテゴリに分類してください:
+
+            ## 1. decline（対応不要・スルー）
+            以下の場合はIssueにコメントして close してください:
+            - 重複報告
+            - 仕様上の正常動作（バグではない）
+            - 対応範囲外の要望
+            - スパムや無関係な内容
+
+            **対応方法:**
+            - 判定理由を丁寧に説明するコメントを追加
+            - `triage:declined` ラベルを付与
+            - Issueをcloseする
+
+            ## 2. pending（人間の判断が必要）
+            以下の場合はラベル付与して人間の確認を待ってください:
+            - 複雑な機能追加の要望
+            - 曖昧な報告（詳細確認が必要）
+            - アーキテクチャ変更を伴う提案
+            - セキュリティ関連の報告
+
+            **対応方法:**
+            - 判定理由と優先度を記載したコメントを追加
+            - `triage:pending` と優先度ラベル（`priority:low/medium/high`）を付与
+            - 適切なカテゴリラベル（`bug`, `enhancement`, `documentation`等）を付与
+            - Issueは開いたまま
+
+            ## 3. implement（自動実装可能）
+            以下の場合は自動実装を試みてください:
+            - 明確なバグ報告（再現手順あり）
+            - 簡単なUI改善（テキスト修正、スタイル調整等）
+            - タイポ修正
+            - 軽微な機能追加
+
+            **対応方法:**
+            - コードベースを確認して実装
+            - 新しいブランチ `automated/issue-${{ github.event.issue.number }}` を作成
+            - 変更をコミット
+            - Draft PRを作成（タイトル: `[Automated] ${{ github.event.issue.title }}`）
+            - PR本文に実装内容とレビューチェックリストを記載
+            - 元のIssueに `triage:automated-pr` ラベルを付与してPR URLをコメント
+
+            ---
+
+            **重要:**
+            - 判定理由は必ず日本語で明確に説明してください
+            - 自動実装する場合は、既存コードの構造とスタイルに従ってください
+            - セキュリティ上の問題がないか慎重に確認してください
+            - 不確実な場合は `pending` に分類してください


### PR DESCRIPTION
## 概要

ユーザーフィードバックIssueを自動トリアージするGitHub Actions Workflowを追加しました。`user-feedback`ラベルが付いたIssueに対してClaude Code Actionが内容を分析し、decline/pending/implementの3カテゴリに分類して適切な対応を自動実行します。

## 変更内容

- `.github/workflows/auto-triage-feedback.yml` を新規追加
- `user-feedback` ラベル付きIssueをトリガーとしてClaude Code Actionを起動
- 3カテゴリのトリアージロジックを実装:
  - **decline**: 重複・仕様動作・スパム等をコメント付きでcloseし `triage:declined` ラベルを付与
  - **pending**: 複雑な要望・曖昧な報告等に `triage:pending` と優先度ラベルを付与して人間の判断を待機
  - **implement**: 明確なバグ・軽微な修正等を自動実装してDraft PRを作成し `triage:automated-pr` ラベルを付与

## 実装の詳細

- Issue作成時（`opened`）とラベル付与時（`labeled`）の両方をトリガーとすることで、後からラベルを付けた場合にも対応
- 自動実装時のブランチ名は `automated/issue-{番号}` の命名規則に統一
- プロンプトは日本語で判定理由の説明を必須化し、不確実なケースは `pending` に分類するよう指示

## テスト方法

1. リポジトリに `user-feedback` ラベルを作成する
2. 新しいIssueを作成し `user-feedback` ラベルを付与する
3. GitHub ActionsのWorkflow実行ログでトリアージ結果を確認する
4. Issueにコメントとラベルが適切に付与されていることを確認する

## レビュー観点

- `ANTHROPIC_API_KEY` シークレットがリポジトリに設定されていることを前提とするため、未設定時の挙動を確認してください
- `contents: write` / `issues: write` 等の広めのPermissionが必要な理由が妥当か確認してください
- 自動実装カテゴリでコード変更を伴うケースにおいて、意図しない変更がコミットされるリスクがないか確認してください

## 参考情報

- [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)
