### PR TITLE
feat(ci): Switch to OpenAI Codex auto-triage

### DIFF
--- a/.github/workflows/auto-triage-feedback.yml
+++ b/.github/workflows/auto-triage-feedback.yml
@@ -11,19 +11,20 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
       issues: write
       pull-requests: write
-      contents: write
-      id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Claude Code Triage
-        uses: anthropics/claude-code-action@v1
+      - name: Codex Triage
+        uses: openai/codex-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: workspace-write
+          output-file: triage-result.txt
           prompt: |
             あなたはPokemon Battle Factory計算機のフィードバックをトリアージするアシスタントです。
 


### PR DESCRIPTION
## 概要

自動トリアージワークフローで使用するAIアクションを、Claude Code ActionからOpenAI Codex Actionに切り替えます。

## 変更内容

- `anthropics/claude-code-action@v1` を `openai/codex-action@v1` に変更
- `ANTHROPIC_API_KEY` を `OPENAI_API_KEY` に変更
- `actions/checkout@v4` を `actions/checkout@v5` に更新
- パーミッションを `contents: write` + `id-token: write` から `contents: read` に変更（最小権限化）
- `sandbox: workspace-write` および `output-file: triage-result.txt` オプションを追加

## レビュー観点

- `OPENAI_API_KEY` シークレットがリポジトリに登録されているか確認してください
- `sandbox: workspace-write` の権限範囲が意図通りかご確認ください
