### PR TITLE
feat(ci): Add GitHub API triage integration

### DIFF
--- a/.github/workflows/auto-triage-feedback.yml
+++ b/.github/workflows/auto-triage-feedback.yml
@@ -20,11 +20,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Codex Triage
+        id: triage
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: workspace-write
-          output-file: triage-result.txt
+          output-file: triage-result.json
           prompt: |
             あなたはPokemon Battle Factory計算機のフィードバックをトリアージするアシスタントです。
 
@@ -39,7 +40,17 @@ jobs:
 
             ---
 
-            このフィードバックを以下の3つのカテゴリに分類してください:
+            このフィードバックを以下の3つのカテゴリに分類し、JSON形式で出力してください:
+
+            ```json
+            {
+              "decision": "decline" | "pending" | "implement",
+              "reasoning": "判定理由（日本語）",
+              "comment": "Issueに投稿するコメント（日本語、マークダウン形式）",
+              "labels": ["triage:declined", ...],
+              "close_issue": true | false
+            }
+            ```
 
             ## 1. decline（対応不要・スルー）
             以下の場合はIssueにコメントして close してください:
@@ -85,6 +96,39 @@ jobs:
 
             **重要:**
             - 判定理由は必ず日本語で明確に説明してください
-            - 自動実装する場合は、既存コードの構造とスタイルに従ってください
-            - セキュリティ上の問題がないか慎重に確認してください
             - 不確実な場合は `pending` に分類してください
+            - 出力は必ずJSON形式にしてください
+
+      - name: Apply Triage Decision
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # JSON結果を読み取り
+          if [ ! -f triage-result.json ]; then
+            echo "Triage result not found"
+            exit 1
+          fi
+
+          DECISION=$(jq -r '.decision' triage-result.json)
+          COMMENT=$(jq -r '.comment' triage-result.json)
+          LABELS=$(jq -r '.labels | join(",")' triage-result.json)
+          CLOSE=$(jq -r '.close_issue' triage-result.json)
+
+          # Issueにコメント追加
+          gh issue comment ${{ github.event.issue.number }} --body "$COMMENT"
+
+          # ラベル追加
+          if [ -n "$LABELS" ]; then
+            IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+            for label in "${LABEL_ARRAY[@]}"; do
+              gh issue edit ${{ github.event.issue.number }} --add-label "$label"
+            done
+          fi
+
+          # Issueをクローズ（必要な場合）
+          if [ "$CLOSE" = "true" ]; then
+            gh issue close ${{ github.event.issue.number }}
+          fi
+
+          echo "✅ Triage decision applied: $DECISION"


### PR DESCRIPTION
## 概要

GitHub APIを使用してOpenAI Codexのトリアージ判定を自動適用する機能を追加しました。Codexの出力形式をテキストからJSONに変更し、判定結果に基づいてIssueへのコメント投稿・ラベル付与・クローズを自動で実行します。

## 変更内容

- Codexの出力形式を `triage-result.txt` から `triage-result.json` に変更
- Codexへのプロンプトを更新し、構造化されたJSON形式（`decision`, `reasoning`, `comment`, `labels`, `close_issue`）での出力を要求
- `Apply Triage Decision` ステップを追加し、JSON結果を解析してGitHub CLIでIssue操作を自動化
  - Issueへのコメント投稿
  - ラベルの付与
  - `close_issue: true` の場合のIssueクローズ

## 実装の詳細

Codex Actionに `id: triage` を付与し、後続ステップで `if: success()` 条件で実行されるシェルスクリプトから `jq` を使ってJSONを解析します。GitHub CLIの `gh issue comment` / `gh issue edit` / `gh issue close` コマンドで各操作を実行しており、`GITHUB_TOKEN` を使用して認証します。

## テスト方法

1. フィードバック系のIssueを作成してワークフローをトリガー
2. Actionsログで `Apply Triage Decision` ステップの出力を確認
3. Issueにコメント・ラベルが付与されること、および `close_issue: true` の場合にクローズされることを確認

## レビュー観点

- `jq` コマンドが実行環境（ubuntu-latest）でデフォルト利用可能か確認してください
- `gh issue edit --add-label` で存在しないラベルを指定した場合のエラーハンドリングが必要か検討してください
- Codexが不正なJSONを出力した場合の挙動を確認してください
