### PR TITLE
docs(docs): Add ER diagram for DB schema redesign

### DIFF
--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -1,0 +1,97 @@
+# ER Diagram
+
+今後採用する想定のER図です。`ability` と `item` はマスタ化し、ファクトリー個体の技構成は関連テーブルで管理します。
+
+```mermaid
+erDiagram
+    Ability ||--o{ Pokemon : ability1
+    Ability ||--o{ Pokemon : ability2
+    Pokemon ||--o{ FactorySet : has
+    Item ||--o{ FactorySet : held_by
+    FactorySet ||--o{ FactorySetMove : has
+    Move ||--o{ FactorySetMove : used_by
+
+    Ability {
+        int id PK
+        string name UK
+    }
+
+    Item {
+        int id PK
+        string name UK
+    }
+
+    Pokemon {
+        int id PK
+        string name
+        int hp
+        int attack
+        int defense
+        int spAttack
+        int spDefense
+        int speed
+        int ability1Id FK
+        int ability2Id FK
+        string imageSrc
+        string type1
+        string type2
+        float weight
+    }
+
+    Move {
+        int id PK
+        string name
+        string type
+        int power
+        int accuracy
+        int pp
+        string classification
+        int super
+    }
+
+    FactorySet {
+        int id PK
+        int pokemonId FK
+        int itemId FK
+        int hp
+        int attack
+        int defense
+        int spAttack
+        int spDefense
+        int speed
+        string nature
+        int group
+    }
+
+    FactorySetMove {
+        int id PK
+        int factorySetId FK
+        int moveId FK
+        int slot
+    }
+```
+
+## Table Roles
+
+- `Ability`: 特性マスタ。`Pokemon` から参照する。
+- `Item`: 持ち物マスタ。`FactorySet` から参照する。
+- `Pokemon`: 種族データ。種族値、タイプ、特性などの基本情報を持つ。
+- `Move`: 技マスタ。
+- `FactorySet`: バトルファクトリー用の個体データ。努力値、性格、持ち物、グループを持つ。
+- `FactorySetMove`: `FactorySet` と `Move` の関連テーブル。技の並び順を `slot` で保持する。
+
+## Design Notes
+
+- `FactorySet` には `name` を持たせない。表示名は `Pokemon.name` を参照する。
+- `Pokemon.ability1Id` は必須、`Pokemon.ability2Id` は任意。
+- `FactorySet.itemId` は任意。持ち物なしを許容する。
+- `FactorySetMove.slot` は 1-4 を想定し、技の並び順を表す。
+- `FactorySetMove` には少なくとも `@@unique([factorySetId, slot])` を付ける。
+- 同一技の重複も禁止したいなら `@@unique([factorySetId, moveId])` も追加する。
+
+## Migration Intent
+
+- 既存の `Pokemon.ability1` / `ability2` の文字列保持は、`Ability` 参照へ置き換える。
+- 既存の `Factory_Pokemon.item` の文字列保持は、`Item` 参照へ置き換える。
+- 既存の `Factory_Pokemon.name` は削除する。
+- 既存の `PokemonMove` は `FactorySetMove` に整理し、`slot` を追加する。

--- a/docs/er-diagram.md
+++ b/docs/er-diagram.md
@@ -6,10 +6,10 @@
 erDiagram
     Ability ||--o{ Pokemon : ability1
     Ability ||--o{ Pokemon : ability2
-    Pokemon ||--o{ FactorySet : has
-    Item ||--o{ FactorySet : held_by
-    FactorySet ||--o{ FactorySetMove : has
-    Move ||--o{ FactorySetMove : used_by
+    Pokemon ||--o{ BattleFactoryPokemon : has
+    Item ||--o{ BattleFactoryPokemon : held_by
+    BattleFactoryPokemon ||--o{ BattleFactoryPokemonMove : has
+    Move ||--o{ BattleFactoryPokemonMove : used_by
 
     Ability {
         int id PK
@@ -49,23 +49,23 @@ erDiagram
         int super
     }
 
-    FactorySet {
+    BattleFactoryPokemon {
         int id PK
         int pokemonId FK
         int itemId FK
-        int hp
-        int attack
-        int defense
-        int spAttack
-        int spDefense
-        int speed
+        int hpEv
+        int attackEv
+        int defenseEv
+        int spAttackEv
+        int spDefenseEv
+        int speedEv
         string nature
         int group
     }
 
-    FactorySetMove {
+    BattleFactoryPokemonMove {
         int id PK
-        int factorySetId FK
+        int battleFactoryPokemonId FK
         int moveId FK
         int slot
     }
@@ -74,24 +74,25 @@ erDiagram
 ## Table Roles
 
 - `Ability`: 特性マスタ。`Pokemon` から参照する。
-- `Item`: 持ち物マスタ。`FactorySet` から参照する。
+- `Item`: 持ち物マスタ。`BattleFactoryPokemon` から参照する。
 - `Pokemon`: 種族データ。種族値、タイプ、特性などの基本情報を持つ。
 - `Move`: 技マスタ。
-- `FactorySet`: バトルファクトリー用の個体データ。努力値、性格、持ち物、グループを持つ。
-- `FactorySetMove`: `FactorySet` と `Move` の関連テーブル。技の並び順を `slot` で保持する。
+- `BattleFactoryPokemon`: バトルファクトリー用の個体データ。努力値、性格、持ち物、グループを持つ。
+- `BattleFactoryPokemonMove`: `BattleFactoryPokemon` と `Move` の関連テーブル。技の並び順を `slot` で保持する。
 
 ## Design Notes
 
-- `FactorySet` には `name` を持たせない。表示名は `Pokemon.name` を参照する。
+- `BattleFactoryPokemon` には `name` を持たせない。表示名は `Pokemon.name` を参照する。
 - `Pokemon.ability1Id` は必須、`Pokemon.ability2Id` は任意。
-- `FactorySet.itemId` は任意。持ち物なしを許容する。
-- `FactorySetMove.slot` は 1-4 を想定し、技の並び順を表す。
-- `FactorySetMove` には少なくとも `@@unique([factorySetId, slot])` を付ける。
-- 同一技の重複も禁止したいなら `@@unique([factorySetId, moveId])` も追加する。
+- `BattleFactoryPokemon.itemId` は任意。持ち物なしを許容する。
+- 努力値カラムは種族値と混同しないように `hpEv` 形式で持つ。
+- `BattleFactoryPokemonMove.slot` は 1-4 を想定し、技の並び順を表す。
+- `BattleFactoryPokemonMove` には `@@unique([battleFactoryPokemonId, slot])` を付ける。
+- 同一技の重複を防ぐため `@@unique([battleFactoryPokemonId, moveId])` も追加する。
 
 ## Migration Intent
 
 - 既存の `Pokemon.ability1` / `ability2` の文字列保持は、`Ability` 参照へ置き換える。
 - 既存の `Factory_Pokemon.item` の文字列保持は、`Item` 参照へ置き換える。
 - 既存の `Factory_Pokemon.name` は削除する。
-- 既存の `PokemonMove` は `FactorySetMove` に整理し、`slot` を追加する。
+- 既存の `PokemonMove` は `BattleFactoryPokemonMove` に整理し、`slot` を追加する。


### PR DESCRIPTION
## 概要

DBスキーマ再設計に向けた ER 図を `docs/er-diagram.md` に追加します。`Ability` と `Item` のマスタ化、`FactorySetMove` による技構成の正規化を主な変更点として設計しています。

## 変更内容

- `docs/er-diagram.md` を新規作成し、再設計後の ER 図（Mermaid）を追加
- 各テーブルの役割・設計方針・移行意図をドキュメント化

## 実装の詳細

現在の文字列保持から以下のように構造を変更する想定です。

- `Ability` / `Item` をマスタテーブルとして切り出し、FK 参照に変更
- `PokemonMove` を `FactorySetMove` に整理し、`slot`（1–4）で技の並び順を管理
- `FactorySet` から `name` を削除し、表示名は `Pokemon.name` を参照
- `FactorySetMove` に `@@unique([factorySetId, slot])` を付与して重複を防止

## 今後の課題

- [ ] `ability1` / `ability2` の文字列カラムを `Ability` FK へ移行する Prisma マイグレーション作成
- [ ] `Factory_Pokemon.item` を `Item` FK へ移行
- [ ] `PokemonMove` → `FactorySetMove` のデータ移行スクリプト作成

## レビュー観点

- ER 図の各テーブル定義・リレーションが意図した設計と一致しているか確認してください
- `FactorySetMove.slot` のユニーク制約の範囲（`slot` のみ vs `moveId` も含む）が適切か確認してください
