### PR TITLE
feat(backend): Switch to database fetching with SSG

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "db:seed": "node prisma/seed/index.js",
+    "postinstall": "prisma generate",
     "postbuild": "next-sitemap",
     "prettier": "npx prettier --write .",
     "lint:fix": "npx @biomejs/biome check . --write --unsafe"

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,0 +1,111 @@
+import prisma from "@/lib/prisma";
+import type { FactoryPokemon } from "@/types/factoryPokemon";
+
+/**
+ * Fetch all factory Pokemon from database with related data
+ */
+export async function getFactoryPokemons(): Promise<FactoryPokemon[]> {
+  const data = await prisma.battleFactoryPokemon.findMany({
+    select: {
+      id: true,
+      hpEv: true,
+      attackEv: true,
+      defenseEv: true,
+      spAttackEv: true,
+      spDefenseEv: true,
+      speedEv: true,
+      nature: true,
+      group: true,
+      pokemon: {
+        select: {
+          id: true,
+          name: true,
+          hp: true,
+          attack: true,
+          defense: true,
+          spAttack: true,
+          spDefense: true,
+          speed: true,
+          type1: true,
+          type2: true,
+          weight: true,
+          imageSrc: true,
+          ability1: { select: { name: true } },
+          ability2: { select: { name: true } },
+        },
+      },
+      item: { select: { name: true } },
+      battleFactoryMoves: {
+        select: {
+          slot: true,
+          move: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              power: true,
+              accuracy: true,
+              pp: true,
+              classification: true,
+              super: true,
+            },
+          },
+        },
+        orderBy: { slot: "asc" },
+      },
+    },
+  });
+
+  // Transform to match FactoryPokemon type
+  return data.map((fp) => ({
+    id: fp.id,
+    hp: fp.hpEv,
+    attack: fp.attackEv,
+    defense: fp.defenseEv,
+    spAttack: fp.spAttackEv,
+    spDefense: fp.spDefenseEv,
+    speed: fp.speedEv,
+    nature: fp.nature,
+    group: fp.group,
+    item: fp.item?.name || "なし",
+    pokemon: {
+      id: fp.pokemon.id,
+      name: fp.pokemon.name,
+      hp: fp.pokemon.hp,
+      attack: fp.pokemon.attack,
+      defense: fp.pokemon.defense,
+      spAttack: fp.pokemon.spAttack,
+      spDefense: fp.pokemon.spDefense,
+      speed: fp.pokemon.speed,
+      type1: fp.pokemon.type1,
+      type2: fp.pokemon.type2,
+      weight: fp.pokemon.weight,
+      imageSrc: fp.pokemon.imageSrc,
+      ability1: fp.pokemon.ability1.name,
+      ability2: fp.pokemon.ability2?.name || null,
+    },
+    moves: fp.battleFactoryMoves.map((m) => m.move),
+  }));
+}
+
+/**
+ * Fetch all abilities from database
+ */
+export async function getAbilities(): Promise<string[]> {
+  const data = await prisma.ability.findMany({
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+  return ["なし", ...data.map((a) => a.name)];
+}
+
+/**
+ * Fetch all items from database
+ */
+export async function getItems(): Promise<string[]> {
+  const data = await prisma.item.findMany({
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+  return ["なし", ...data.map((i) => i.name)];
+}

--- a/src/pages/api/factory_pokemon.ts
+++ b/src/pages/api/factory_pokemon.ts
@@ -6,21 +6,39 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  const data = await prisma.factory_Pokemon.findMany({
+  const data = await prisma.battleFactoryPokemon.findMany({
     select: {
       id: true,
-      hp: true,
-      attack: true,
-      defense: true,
-      spAttack: true,
-      spDefense: true,
-      speed: true,
-      item: true,
+      hpEv: true,
+      attackEv: true,
+      defenseEv: true,
+      spAttackEv: true,
+      spDefenseEv: true,
+      speedEv: true,
       nature: true,
       group: true,
-      pokemon: true,
-      moves: {
+      pokemon: {
         select: {
+          id: true,
+          name: true,
+          hp: true,
+          attack: true,
+          defense: true,
+          spAttack: true,
+          spDefense: true,
+          speed: true,
+          type1: true,
+          type2: true,
+          weight: true,
+          imageSrc: true,
+          ability1: { select: { name: true } },
+          ability2: { select: { name: true } },
+        },
+      },
+      item: { select: { name: true } },
+      battleFactoryMoves: {
+        select: {
+          slot: true,
           move: {
             select: {
               id: true,
@@ -34,14 +52,41 @@ export default async function handler(
             },
           },
         },
+        orderBy: { slot: "asc" },
       },
     },
   });
 
-  const cleanedData = data.map((fp) => ({
-    ...fp,
-    moves: fp.moves.map((m) => m.move),
+  // Transform to match FactoryPokemon type
+  const factoryPokemons = data.map((fp) => ({
+    id: fp.id,
+    hp: fp.hpEv,
+    attack: fp.attackEv,
+    defense: fp.defenseEv,
+    spAttack: fp.spAttackEv,
+    spDefense: fp.spDefenseEv,
+    speed: fp.speedEv,
+    nature: fp.nature,
+    group: fp.group,
+    item: fp.item?.name || "なし",
+    pokemon: {
+      id: fp.pokemon.id,
+      name: fp.pokemon.name,
+      hp: fp.pokemon.hp,
+      attack: fp.pokemon.attack,
+      defense: fp.pokemon.defense,
+      spAttack: fp.pokemon.spAttack,
+      spDefense: fp.pokemon.spDefense,
+      speed: fp.pokemon.speed,
+      type1: fp.pokemon.type1,
+      type2: fp.pokemon.type2,
+      weight: fp.pokemon.weight,
+      imageSrc: fp.pokemon.imageSrc,
+      ability1: fp.pokemon.ability1.name,
+      ability2: fp.pokemon.ability2?.name || null,
+    },
+    moves: fp.battleFactoryMoves.map((m) => m.move),
   }));
 
-  res.status(200).json(cleanedData);
+  res.status(200).json(factoryPokemons);
 }

--- a/src/pages/api/factory_pokemon.ts
+++ b/src/pages/api/factory_pokemon.ts
@@ -1,92 +1,11 @@
-import prisma from "@/lib/prisma";
 // pages/api/factory-pokemon.ts
 import type { NextApiRequest, NextApiResponse } from "next";
+import { getFactoryPokemons } from "@/lib/queries";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  const data = await prisma.battleFactoryPokemon.findMany({
-    select: {
-      id: true,
-      hpEv: true,
-      attackEv: true,
-      defenseEv: true,
-      spAttackEv: true,
-      spDefenseEv: true,
-      speedEv: true,
-      nature: true,
-      group: true,
-      pokemon: {
-        select: {
-          id: true,
-          name: true,
-          hp: true,
-          attack: true,
-          defense: true,
-          spAttack: true,
-          spDefense: true,
-          speed: true,
-          type1: true,
-          type2: true,
-          weight: true,
-          imageSrc: true,
-          ability1: { select: { name: true } },
-          ability2: { select: { name: true } },
-        },
-      },
-      item: { select: { name: true } },
-      battleFactoryMoves: {
-        select: {
-          slot: true,
-          move: {
-            select: {
-              id: true,
-              name: true,
-              type: true,
-              power: true,
-              accuracy: true,
-              pp: true,
-              classification: true,
-              super: true,
-            },
-          },
-        },
-        orderBy: { slot: "asc" },
-      },
-    },
-  });
-
-  // Transform to match FactoryPokemon type
-  const factoryPokemons = data.map((fp) => ({
-    id: fp.id,
-    hp: fp.hpEv,
-    attack: fp.attackEv,
-    defense: fp.defenseEv,
-    spAttack: fp.spAttackEv,
-    spDefense: fp.spDefenseEv,
-    speed: fp.speedEv,
-    nature: fp.nature,
-    group: fp.group,
-    item: fp.item?.name || "なし",
-    pokemon: {
-      id: fp.pokemon.id,
-      name: fp.pokemon.name,
-      hp: fp.pokemon.hp,
-      attack: fp.pokemon.attack,
-      defense: fp.pokemon.defense,
-      spAttack: fp.pokemon.spAttack,
-      spDefense: fp.pokemon.spDefense,
-      speed: fp.pokemon.speed,
-      type1: fp.pokemon.type1,
-      type2: fp.pokemon.type2,
-      weight: fp.pokemon.weight,
-      imageSrc: fp.pokemon.imageSrc,
-      ability1: fp.pokemon.ability1.name,
-      ability2: fp.pokemon.ability2?.name || null,
-    },
-    moves: fp.battleFactoryMoves.map((m) => m.move),
-  }));
-
+  const factoryPokemons = await getFactoryPokemons();
   res.status(200).json(factoryPokemons);
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import { Attackers } from "@/components/domain/attacker/attackers";
 import { DefenderCard } from "@/components/domain/defender/defender-card";
 import { EnvCard } from "@/components/domain/env/env-card";
@@ -21,6 +19,7 @@ import { setDefender } from "@/store/slices/defenderSlice";
 import { setIsNejiki, setLevel, setTimes } from "@/store/slices/settingsSlice";
 import type { RootState } from "@/store/store";
 import type { FactoryPokemon } from "@/types/factoryPokemon";
+import prisma from "@/lib/prisma";
 import { ArrowLeftRight, ArrowUpDown } from "lucide-react";
 import type { GetStaticProps } from "next";
 import Head from "next/head";
@@ -31,16 +30,91 @@ interface HomeProps {
 }
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
-  const filePath = path.join(
-    process.cwd(),
-    "public/data/factory-pokemons.json",
-  );
-  const fileContents = await fs.readFile(filePath, "utf8");
-  const factoryPokemons = JSON.parse(fileContents);
+  const data = await prisma.battleFactoryPokemon.findMany({
+    select: {
+      id: true,
+      hpEv: true,
+      attackEv: true,
+      defenseEv: true,
+      spAttackEv: true,
+      spDefenseEv: true,
+      speedEv: true,
+      nature: true,
+      group: true,
+      pokemon: {
+        select: {
+          id: true,
+          name: true,
+          hp: true,
+          attack: true,
+          defense: true,
+          spAttack: true,
+          spDefense: true,
+          speed: true,
+          type1: true,
+          type2: true,
+          weight: true,
+          imageSrc: true,
+          ability1: { select: { name: true } },
+          ability2: { select: { name: true } },
+        },
+      },
+      item: { select: { name: true } },
+      battleFactoryMoves: {
+        select: {
+          slot: true,
+          move: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              power: true,
+              accuracy: true,
+              pp: true,
+              classification: true,
+              super: true,
+            },
+          },
+        },
+        orderBy: { slot: "asc" },
+      },
+    },
+  });
+
+  // Transform to match FactoryPokemon type
+  const factoryPokemons = data.map((fp) => ({
+    id: fp.id,
+    hp: fp.hpEv,
+    attack: fp.attackEv,
+    defense: fp.defenseEv,
+    spAttack: fp.spAttackEv,
+    spDefense: fp.spDefenseEv,
+    speed: fp.speedEv,
+    nature: fp.nature,
+    group: fp.group,
+    item: fp.item?.name || "なし",
+    pokemon: {
+      id: fp.pokemon.id,
+      name: fp.pokemon.name,
+      hp: fp.pokemon.hp,
+      attack: fp.pokemon.attack,
+      defense: fp.pokemon.defense,
+      spAttack: fp.pokemon.spAttack,
+      spDefense: fp.pokemon.spDefense,
+      speed: fp.pokemon.speed,
+      type1: fp.pokemon.type1,
+      type2: fp.pokemon.type2,
+      weight: fp.pokemon.weight,
+      imageSrc: fp.pokemon.imageSrc,
+      ability1: fp.pokemon.ability1.name,
+      ability2: fp.pokemon.ability2?.name || null,
+    },
+    moves: fp.battleFactoryMoves.map((m) => m.move),
+  }));
 
   return {
     props: {
-      factoryPokemons,
+      factoryPokemons: JSON.parse(JSON.stringify(factoryPokemons)),
     },
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,7 +19,7 @@ import { setDefender } from "@/store/slices/defenderSlice";
 import { setIsNejiki, setLevel, setTimes } from "@/store/slices/settingsSlice";
 import type { RootState } from "@/store/store";
 import type { FactoryPokemon } from "@/types/factoryPokemon";
-import prisma from "@/lib/prisma";
+import { getFactoryPokemons } from "@/lib/queries";
 import { ArrowLeftRight, ArrowUpDown } from "lucide-react";
 import type { GetStaticProps } from "next";
 import Head from "next/head";
@@ -30,87 +30,7 @@ interface HomeProps {
 }
 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
-  const data = await prisma.battleFactoryPokemon.findMany({
-    select: {
-      id: true,
-      hpEv: true,
-      attackEv: true,
-      defenseEv: true,
-      spAttackEv: true,
-      spDefenseEv: true,
-      speedEv: true,
-      nature: true,
-      group: true,
-      pokemon: {
-        select: {
-          id: true,
-          name: true,
-          hp: true,
-          attack: true,
-          defense: true,
-          spAttack: true,
-          spDefense: true,
-          speed: true,
-          type1: true,
-          type2: true,
-          weight: true,
-          imageSrc: true,
-          ability1: { select: { name: true } },
-          ability2: { select: { name: true } },
-        },
-      },
-      item: { select: { name: true } },
-      battleFactoryMoves: {
-        select: {
-          slot: true,
-          move: {
-            select: {
-              id: true,
-              name: true,
-              type: true,
-              power: true,
-              accuracy: true,
-              pp: true,
-              classification: true,
-              super: true,
-            },
-          },
-        },
-        orderBy: { slot: "asc" },
-      },
-    },
-  });
-
-  // Transform to match FactoryPokemon type
-  const factoryPokemons = data.map((fp) => ({
-    id: fp.id,
-    hp: fp.hpEv,
-    attack: fp.attackEv,
-    defense: fp.defenseEv,
-    spAttack: fp.spAttackEv,
-    spDefense: fp.spDefenseEv,
-    speed: fp.speedEv,
-    nature: fp.nature,
-    group: fp.group,
-    item: fp.item?.name || "なし",
-    pokemon: {
-      id: fp.pokemon.id,
-      name: fp.pokemon.name,
-      hp: fp.pokemon.hp,
-      attack: fp.pokemon.attack,
-      defense: fp.pokemon.defense,
-      spAttack: fp.pokemon.spAttack,
-      spDefense: fp.pokemon.spDefense,
-      speed: fp.pokemon.speed,
-      type1: fp.pokemon.type1,
-      type2: fp.pokemon.type2,
-      weight: fp.pokemon.weight,
-      imageSrc: fp.pokemon.imageSrc,
-      ability1: fp.pokemon.ability1.name,
-      ability2: fp.pokemon.ability2?.name || null,
-    },
-    moves: fp.battleFactoryMoves.map((m) => m.move),
-  }));
+  const factoryPokemons = await getFactoryPokemons();
 
   return {
     props: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,7 +34,7 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
 
   return {
     props: {
-      factoryPokemons: JSON.parse(JSON.stringify(factoryPokemons)),
+      factoryPokemons,
     },
   };
 };

--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -51,7 +51,7 @@ export const getStaticProps: GetStaticProps<PokeSearchProps> = async () => {
 
   return {
     props: {
-      factoryPokemons: JSON.parse(JSON.stringify(factoryPokemons)),
+      factoryPokemons,
       abilities,
       items,
     },

--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -1,5 +1,3 @@
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import { filterFactoryPokemons } from "@/components/general/auto-complete";
 import { TypeBadge } from "@/components/general/type-badge";
 import { Badge } from "@/components/ui/badge";
@@ -23,8 +21,6 @@ import { SelectGroup } from "@/components/ui/select";
 import { SelectContent } from "@/components/ui/select";
 import { Select, SelectValue } from "@/components/ui/select";
 import { SelectTrigger } from "@/components/ui/select";
-import { abilities } from "@/constants/abilities";
-import { items } from "@/constants/items";
 import { findItems, timesItems } from "@/constants/ivs";
 import { calculateStatus } from "@/functions/calculate_status";
 import { toggleKana } from "@/functions/convert_hiragana_katakana";
@@ -33,6 +29,7 @@ import { setAttacker } from "@/store/slices/attackerSlice";
 import { setDefender } from "@/store/slices/defenderSlice";
 import type { FactoryPokemon } from "@/types/factoryPokemon";
 import type { Move } from "@/types/move";
+import prisma from "@/lib/prisma";
 import { Filter, Search, Shield, Sword } from "lucide-react";
 import type { GetStaticProps } from "next";
 import Head from "next/head";
@@ -43,27 +40,123 @@ import { useDispatch } from "react-redux";
 
 interface PokeSearchProps {
   factoryPokemons: FactoryPokemon[];
+  abilities: string[];
+  items: string[];
 }
 
 export const getStaticProps: GetStaticProps<PokeSearchProps> = async () => {
-  const filePath = path.join(
-    process.cwd(),
-    "public/data/factory-pokemons.json",
-  );
-  const fileContents = await fs.readFile(filePath, "utf8");
-  const factoryPokemons = JSON.parse(fileContents);
+  const data = await prisma.battleFactoryPokemon.findMany({
+    select: {
+      id: true,
+      hpEv: true,
+      attackEv: true,
+      defenseEv: true,
+      spAttackEv: true,
+      spDefenseEv: true,
+      speedEv: true,
+      nature: true,
+      group: true,
+      pokemon: {
+        select: {
+          id: true,
+          name: true,
+          hp: true,
+          attack: true,
+          defense: true,
+          spAttack: true,
+          spDefense: true,
+          speed: true,
+          type1: true,
+          type2: true,
+          weight: true,
+          imageSrc: true,
+          ability1: { select: { name: true } },
+          ability2: { select: { name: true } },
+        },
+      },
+      item: { select: { name: true } },
+      battleFactoryMoves: {
+        select: {
+          slot: true,
+          move: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              power: true,
+              accuracy: true,
+              pp: true,
+              classification: true,
+              super: true,
+            },
+          },
+        },
+        orderBy: { slot: "asc" },
+      },
+    },
+  });
+
+  const abilitiesData = await prisma.ability.findMany({
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+
+  const itemsData = await prisma.item.findMany({
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+
+  // Transform to match FactoryPokemon type
+  const factoryPokemons = data.map((fp) => ({
+    id: fp.id,
+    hp: fp.hpEv,
+    attack: fp.attackEv,
+    defense: fp.defenseEv,
+    spAttack: fp.spAttackEv,
+    spDefense: fp.spDefenseEv,
+    speed: fp.speedEv,
+    nature: fp.nature,
+    group: fp.group,
+    item: fp.item?.name || "なし",
+    pokemon: {
+      id: fp.pokemon.id,
+      name: fp.pokemon.name,
+      hp: fp.pokemon.hp,
+      attack: fp.pokemon.attack,
+      defense: fp.pokemon.defense,
+      spAttack: fp.pokemon.spAttack,
+      spDefense: fp.pokemon.spDefense,
+      speed: fp.pokemon.speed,
+      type1: fp.pokemon.type1,
+      type2: fp.pokemon.type2,
+      weight: fp.pokemon.weight,
+      imageSrc: fp.pokemon.imageSrc,
+      ability1: fp.pokemon.ability1.name,
+      ability2: fp.pokemon.ability2?.name || null,
+    },
+    moves: fp.battleFactoryMoves.map((m) => m.move),
+  }));
+
+  const abilities = ["なし", ...abilitiesData.map((a) => a.name)];
+  const items = ["なし", ...itemsData.map((i) => i.name)];
 
   return {
     props: {
-      factoryPokemons,
+      factoryPokemons: JSON.parse(JSON.stringify(factoryPokemons)),
+      abilities,
+      items,
     },
   };
 };
 
 export default function PokeSearch({
   factoryPokemons: initialFactoryPokemons,
+  abilities: abilitiesProp,
+  items: itemsProp,
 }: PokeSearchProps) {
   const [factoryPokemons] = useState<FactoryPokemon[]>(initialFactoryPokemons);
+  const [abilities] = useState<string[]>(abilitiesProp);
+  const [items] = useState<string[]>(itemsProp);
   const [level, setLevel] = useState<number>(100);
   const [times, setTimes] = useState<number>(1);
   const [item, setItem] = useState<string>("なし");

--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -29,7 +29,7 @@ import { setAttacker } from "@/store/slices/attackerSlice";
 import { setDefender } from "@/store/slices/defenderSlice";
 import type { FactoryPokemon } from "@/types/factoryPokemon";
 import type { Move } from "@/types/move";
-import prisma from "@/lib/prisma";
+import { getFactoryPokemons, getAbilities, getItems } from "@/lib/queries";
 import { Filter, Search, Shield, Sword } from "lucide-react";
 import type { GetStaticProps } from "next";
 import Head from "next/head";
@@ -45,100 +45,9 @@ interface PokeSearchProps {
 }
 
 export const getStaticProps: GetStaticProps<PokeSearchProps> = async () => {
-  const data = await prisma.battleFactoryPokemon.findMany({
-    select: {
-      id: true,
-      hpEv: true,
-      attackEv: true,
-      defenseEv: true,
-      spAttackEv: true,
-      spDefenseEv: true,
-      speedEv: true,
-      nature: true,
-      group: true,
-      pokemon: {
-        select: {
-          id: true,
-          name: true,
-          hp: true,
-          attack: true,
-          defense: true,
-          spAttack: true,
-          spDefense: true,
-          speed: true,
-          type1: true,
-          type2: true,
-          weight: true,
-          imageSrc: true,
-          ability1: { select: { name: true } },
-          ability2: { select: { name: true } },
-        },
-      },
-      item: { select: { name: true } },
-      battleFactoryMoves: {
-        select: {
-          slot: true,
-          move: {
-            select: {
-              id: true,
-              name: true,
-              type: true,
-              power: true,
-              accuracy: true,
-              pp: true,
-              classification: true,
-              super: true,
-            },
-          },
-        },
-        orderBy: { slot: "asc" },
-      },
-    },
-  });
-
-  const abilitiesData = await prisma.ability.findMany({
-    select: { name: true },
-    orderBy: { name: "asc" },
-  });
-
-  const itemsData = await prisma.item.findMany({
-    select: { name: true },
-    orderBy: { name: "asc" },
-  });
-
-  // Transform to match FactoryPokemon type
-  const factoryPokemons = data.map((fp) => ({
-    id: fp.id,
-    hp: fp.hpEv,
-    attack: fp.attackEv,
-    defense: fp.defenseEv,
-    spAttack: fp.spAttackEv,
-    spDefense: fp.spDefenseEv,
-    speed: fp.speedEv,
-    nature: fp.nature,
-    group: fp.group,
-    item: fp.item?.name || "なし",
-    pokemon: {
-      id: fp.pokemon.id,
-      name: fp.pokemon.name,
-      hp: fp.pokemon.hp,
-      attack: fp.pokemon.attack,
-      defense: fp.pokemon.defense,
-      spAttack: fp.pokemon.spAttack,
-      spDefense: fp.pokemon.spDefense,
-      speed: fp.pokemon.speed,
-      type1: fp.pokemon.type1,
-      type2: fp.pokemon.type2,
-      weight: fp.pokemon.weight,
-      imageSrc: fp.pokemon.imageSrc,
-      ability1: fp.pokemon.ability1.name,
-      ability2: fp.pokemon.ability2?.name || null,
-    },
-    moves: fp.battleFactoryMoves.map((m) => m.move),
-  }));
-
-  const abilities = ["なし", ...abilitiesData.map((a) => a.name)];
-  const items = ["なし", ...itemsData.map((i) => i.name)];
+  const factoryPokemons = await getFactoryPokemons();
+  const abilities = await getAbilities();
+  const items = await getItems();
 
   return {
     props: {


### PR DESCRIPTION
## 概要

JSONファイルからのデータ取得をPostgreSQLデータベース（Prisma）への直接クエリに切り替え、SSG（Static Site Generation）でビルド時にデータを取得するよう変更した。

## 変更内容

- `getStaticProps`でJSONファイル読み込みをPrismaクエリに置き換え（`index.tsx`, `poke-search.tsx`）
- API endpoint `factory_pokemon.ts` のクエリを新スキーマ（`battleFactoryPokemon`モデル）に対応させた
- `poke-search.tsx`のアビリティ・アイテムリストを定数ファイルからDBクエリ取得に変更し、`props`経由で渡すよう修正
- Prismaレスポンスを`FactoryPokemon`型に合わせてトランスフォームする処理を追加

## 破壊的変更 (Breaking Changes)

- `factory_pokemon` APIのレスポンス形式が変更（旧スキーマ`factory_Pokemon`から新スキーマ`battleFactoryPokemon`へ移行）
- `poke-search.tsx`のアビリティ・アイテムリストが定数から動的データに変更

## テスト方法

1. `DATABASE_URL`環境変数が設定されていることを確認
2. `npm run build`でSSGビルドが正常に完了することを確認
3. トップページでポケモンデータが正しく表示されること
4. `poke-search`ページでアビリティ・アイテムフィルターが正しく機能すること

## レビュー観点

- `getStaticProps`内のPrismaクエリが`index.tsx`と`poke-search.tsx`で重複しているため、将来的な共通化の余地がある
- `JSON.parse(JSON.stringify(...))`によるシリアライズが必要な理由（Prismaの`Decimal`型等の対応）を確認
- DBに登録されていないアイテムがある場合のフォールバック（`"なし"`）が適切か確認
