### PR TITLE
refactor(frontend): Separate item effect logic

### DIFF
--- a/src/functions/calculate_mc.ts
+++ b/src/functions/calculate_mc.ts
@@ -1,4 +1,4 @@
-import { typeReduceHalf } from "@/constants/items";
+import { typeReduceHalf } from "@/functions/item_effects";
 import type { Attacker } from "@/types/attacker";
 import type { Defender } from "@/types/defender";
 

--- a/src/functions/calculate_movePower.ts
+++ b/src/functions/calculate_movePower.ts
@@ -1,4 +1,4 @@
-import { typeStrengthen } from "@/constants/items";
+import { typeStrengthen } from "@/functions/item_effects";
 import type { Attacker } from "@/types/attacker";
 
 export const calculateMovePower = (attacker: Attacker) => {

--- a/src/functions/item_effects.ts
+++ b/src/functions/item_effects.ts
@@ -1,0 +1,67 @@
+const strengthenItemsMap: Record<string, string[]> = {
+  ノーマル: ["シルクのスカーフ"],
+  みず: ["うしおのおこう", "さざなみのおこう", "しんぴのしずく"],
+  くさ: ["おはなのおこう", "きせきのタネ"],
+  ほのお: ["もくたん"],
+  でんき: ["じしゃく"],
+  こおり: ["とけないこおり"],
+  かくとう: ["くろおび"],
+  あく: ["くろいメガネ"],
+  どく: ["どくバリ"],
+  じめん: ["やわらかいすな"],
+  ひこう: ["するどいくちばし"],
+  エスパー: ["まがったスプーン", "あやしいおこう"],
+  いわ: ["がんせきおこう", "かたいいし"],
+  むし: ["ぎんのこな"],
+  ゴースト: ["のろいのおふだ"],
+  ドラゴン: ["りゅうのキバ"],
+  はがね: ["メタルコート"],
+};
+
+export const typeStrengthen = ({
+  type,
+  item,
+}: {
+  type: string;
+  item: string;
+}) => {
+  const strengthenItems = strengthenItemsMap[type];
+  if (strengthenItems?.includes(item)) {
+    return 1.2;
+  }
+  return 1;
+};
+
+const reduceByHalfItemsMap: Record<string, string[]> = {
+  ノーマル: ["ホズのみ"],
+  みず: ["イトケのみ"],
+  くさ: ["リンドのみ"],
+  ほのお: ["オッカのみ"],
+  でんき: ["ソクノのみ"],
+  こおり: ["ヤチェのみ"],
+  かくとう: ["ヨプのみ"],
+  あく: ["ナモのみ"],
+  どく: ["ビアーのみ"],
+  じめん: ["シュカのみ"],
+  ひこう: ["バコウのみ"],
+  エスパー: ["ウタンのみ"],
+  いわ: ["ヨロギのみ"],
+  むし: ["タンガのみ"],
+  ゴースト: ["カシブのみ"],
+  ドラゴン: ["ハバンのみ"],
+  はがね: ["リリバのみ"],
+};
+
+export const typeReduceHalf = ({
+  type,
+  item,
+}: {
+  type: string;
+  item: string;
+}) => {
+  const halfItems = reduceByHalfItemsMap[type];
+  if (halfItems?.includes(item)) {
+    return 0.5;
+  }
+  return 1;
+};


### PR DESCRIPTION
## 概要

アイテムの効果に関するビジネスロジックを定数ファイルから分離し、専用の関数ファイルに移動するリファクタリングを行った。

## 変更内容

- `src/functions/item_effects.ts` を新規作成し、`typeStrengthen` および `typeReduceHalf` の関数を移動
- `src/constants/items` からのインポートを `src/functions/item_effects` に変更（`calculate_mc.ts`、`calculate_movePower.ts`）

## 実装の詳細

`typeStrengthen`（タイプ強化アイテムの倍率計算）と `typeReduceHalf`（タイプ半減きのみの倍率計算）は定数ではなくビジネスロジックであるため、`/src/constants/` から `/src/functions/` に移動した。これにより、定数ファイルはデータ保持のみに責務が限定され、ロジックと定数の役割が明確に分離される。

## レビュー観点

- `item_effects.ts` に移動したロジックが元の定数ファイルの実装と同等であるか確認してください
- インポートパスの変更漏れがないか確認してください
