### PR TITLE
fix: Supabase DB keep-alive対応とseedのマルチステートメントバグ修正

### DIFF
--- a/.github/workflows/keep-db-alive.yml
+++ b/.github/workflows/keep-db-alive.yml
@@ -1,0 +1,15 @@
+name: Keep Supabase DB Alive
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # 毎週日曜 00:00 UTC
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping DB
+        run: psql "$DATABASE_URL" -c "SELECT 1"
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/prisma/seed/index.js
+++ b/prisma/seed/index.js
@@ -18,14 +18,12 @@ function loadFactoryPokemons() {
 }
 
 async function resetSequences() {
-  await prisma.$executeRawUnsafe(`
-    SELECT setval(pg_get_serial_sequence('"Pokemon"', 'id'), COALESCE((SELECT MAX("id") FROM "Pokemon"), 1), true);
-    SELECT setval(pg_get_serial_sequence('"Move"', 'id'), COALESCE((SELECT MAX("id") FROM "Move"), 1), true);
-    SELECT setval(pg_get_serial_sequence('"BattleFactoryPokemon"', 'id'), COALESCE((SELECT MAX("id") FROM "BattleFactoryPokemon"), 1), true);
-    SELECT setval(pg_get_serial_sequence('"Ability"', 'id'), COALESCE((SELECT MAX("id") FROM "Ability"), 1), true);
-    SELECT setval(pg_get_serial_sequence('"Item"', 'id'), COALESCE((SELECT MAX("id") FROM "Item"), 1), true);
-    SELECT setval(pg_get_serial_sequence('"BattleFactoryPokemonMove"', 'id'), COALESCE((SELECT MAX("id") FROM "BattleFactoryPokemonMove"), 1), true);
-  `);
+  const tables = ["Pokemon", "Move", "BattleFactoryPokemon", "Ability", "Item", "BattleFactoryPokemonMove"];
+  for (const table of tables) {
+    await prisma.$executeRawUnsafe(
+      `SELECT setval(pg_get_serial_sequence('"${table}"', 'id'), COALESCE((SELECT MAX("id") FROM "${table}"), 1), true)`,
+    );
+  }
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- `resetSequences()` で複数のSQLを1つの `$executeRawUnsafe()` に渡していたため、SupabaseのpoolerがPrepared Statementモードで `ERROR: cannot insert multiple commands into a prepared statement` を返すバグを修正
- Supabase freeプランはアクティビティがない場合7日でDB pauseされるため、週1回 `SELECT 1` を実行するGitHub Actionsワークフローを追加

## Test plan

- [ ] `pnpm db:seed` が正常完了することを確認
- [ ] GitHubリポジトリの Secrets に `DATABASE_URL` を登録する
- [ ] Actions タブから `keep-db-alive` を手動実行して疎通確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)