### PR TITLE
feat: Google Analyticsイベント計測を追加

### DIFF
--- a/src/components/domain/attacker/attacker-reserve.tsx
+++ b/src/components/domain/attacker/attacker-reserve.tsx
@@ -6,6 +6,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { setAttacker } from "@/store/slices/attackerSlice";
 import type { RootState } from "@/store/store";
 import type { FactoryPokemon } from "@/types/factoryPokemon";
+import { sendGAEvent } from "@next/third-parties/google";
 import { Avatar } from "@radix-ui/react-avatar";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -26,6 +27,7 @@ export const AttackerReserve = ({
       pokemon !== attacker.factoryPokemon
     ) {
       setSpares([...spares, pokemon]);
+      sendGAEvent("event", "spare_add", { role: "attacker" });
     }
   };
 
@@ -55,6 +57,7 @@ export const AttackerReserve = ({
         }),
       );
 
+      sendGAEvent("event", "spare_swap", { role: "attacker" });
       setSelectedId("");
     }
   };

--- a/src/components/domain/defender/defender-reserve.tsx
+++ b/src/components/domain/defender/defender-reserve.tsx
@@ -1,6 +1,7 @@
 import { AutoComplete } from "@/components/general/auto-complete";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { setDefender } from "@/store/slices/defenderSlice";
+import { sendGAEvent } from "@next/third-parties/google";
 import type { RootState } from "@/store/store";
 import type { FactoryPokemon } from "@/types/factoryPokemon";
 import { Avatar } from "@radix-ui/react-avatar";
@@ -26,6 +27,7 @@ export const DefenderReserve = ({
       pokemon !== defender.factoryPokemon
     ) {
       setSpares([...spares, pokemon]);
+      sendGAEvent("event", "spare_add", { role: "defender" });
     }
   };
 
@@ -50,6 +52,7 @@ export const DefenderReserve = ({
 
       dispatch(setDefender({ pokemon: pokemon, iv: 4 * (settings.times - 1) }));
 
+      sendGAEvent("event", "spare_swap", { role: "defender" });
       setSelectedId("");
     }
   };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,23 @@
 import { store } from "@/store/store";
 import "@/styles/globals.css";
-import { GoogleAnalytics } from "@next/third-parties/google";
+import { GoogleAnalytics, sendGAEvent } from "@next/third-parties/google";
 import type { AppProps } from "next/app";
 import Head from "next/head";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { Provider } from "react-redux";
 
 export default function App({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      sendGAEvent("event", "page_transition", { from: router.asPath, to: url });
+    };
+    router.events.on("routeChangeStart", handleRouteChange);
+    return () => router.events.off("routeChangeStart", handleRouteChange);
+  }, [router.events]);
+
   return (
     <Provider store={store}>
       <Head>

--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -510,7 +510,7 @@ export const ListPokemonCard = ({
         iv: ivBonus,
       }),
     );
-    sendGAEvent("event", "set_pokemon", { role: "attacker", pokemon_name: pokemon.pokemon.name });
+    sendGAEvent("event", "set_pokemon_from_search_page", { role: "attacker" });
     setIsDialogOpen(false);
     router.push("/");
   };
@@ -522,7 +522,7 @@ export const ListPokemonCard = ({
         iv: ivBonus,
       }),
     );
-    sendGAEvent("event", "set_pokemon", { role: "defender", pokemon_name: pokemon.pokemon.name });
+    sendGAEvent("event", "set_pokemon_from_search_page", { role: "defender" });
     setIsDialogOpen(false);
     router.push("/");
   };

--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -32,6 +32,7 @@ import type { Move } from "@/types/move";
 import { getFactoryPokemons, getAbilities, getItems } from "@/lib/queries";
 import { Filter, Search, Shield, Sword } from "lucide-react";
 import type { GetStaticProps } from "next";
+import { sendGAEvent } from "@next/third-parties/google";
 import Head from "next/head";
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -509,6 +510,7 @@ export const ListPokemonCard = ({
         iv: ivBonus,
       }),
     );
+    sendGAEvent("event", "set_pokemon", { role: "attacker", pokemon_name: pokemon.pokemon.name });
     setIsDialogOpen(false);
     router.push("/");
   };
@@ -520,6 +522,7 @@ export const ListPokemonCard = ({
         iv: ivBonus,
       }),
     );
+    sendGAEvent("event", "set_pokemon", { role: "defender", pokemon_name: pokemon.pokemon.name });
     setIsDialogOpen(false);
     router.push("/");
   };


### PR DESCRIPTION
## Summary

- `_app.tsx` の `routeChangeStart` でページ遷移イベント（`page_transition`）を一括収集。`from` / `to` パラメータでどの遷移パターンが多いか分析できる
- ポケモン検索画面の「攻撃側にセット」「防御側にセット」ボタンに `set_pokemon` イベントを追加