### PR TITLE
fix: poke-searchのnext/imageにunoptimizedを追加してEdge Requestsを削減

### DIFF
--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -550,6 +550,7 @@ export const ListPokemonCard = ({
               height={48}
               className="w-12 h-12"
               loading="lazy"
+              unoptimized
             />
           </div>
           <div>
@@ -611,6 +612,7 @@ export const ListPokemonCard = ({
                 width={32}
                 height={32}
                 className="w-8 h-8"
+                unoptimized
               />
               {pokemon.pokemon.name}をセット
             </DialogTitle>


### PR DESCRIPTION
## Summary

- `poke-search.tsx` の `Image` コンポーネント2箇所に `unoptimized` prop を追加
- VercelホビープランのEdge Request上限に当たっていた問題への対処

## 背景

`next/image` は `/_next/image` という Vercel の Image Optimization Edge Function を経由する。ポケモンのスプライト画像（48×48、32×32px）はもともとサイズが小さく、最適化の恩恵がほぼないにもかかわらず、リスト表示時に多数の Edge Request が発生していた。

`unoptimized` を指定することで Edge Function をバイパスし、`/public` 以下の静的ファイルとして CDN から直接配信される。`next/image` の遅延読み込み・レイアウトシフト防止などの機能はそのまま維持される。

## Test plan

- [ ] poke-search ページでポケモン画像が正常に表示されること
- [ ] ダイアログ内のポケモン画像が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)