### PR TITLE
feat: [B案] カードにセット誘導ヒントを追加（Dialog維持）

### DIFF
--- a/src/pages/poke-search.tsx
+++ b/src/pages/poke-search.tsx
@@ -599,6 +599,12 @@ export const ListPokemonCard = ({
             </div>
           </div>
         </div>
+
+        <div className="flex items-center justify-end gap-1 mt-3 text-xs text-slate-400">
+          <Sword className="h-3 w-3" />
+          <Shield className="h-3 w-3" />
+          <span>タップしてセット</span>
+        </div>
       </div>
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>


### PR DESCRIPTION
## 概要

ポケモン検索画面のカード下部にセット機能の誘導ヒントを追加。

**変更前**: カードをタップできることが視覚的に分からない
**変更後**: カード下部に ⚔️🛡️ アイコン + 「タップしてセット」テキストを表示

Dialogのフローは変更なし。

## A案との比較

- **この案（B案）**: Dialog維持、ヒント追加のみ（最小変更）
- A案（[#62](https://github.com/tsukuneA1/nejiki_calculator/pull/62)）: Dialog廃止、ボタン直接表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)