### PR TITLE
feat: /images/poke-imageにキャッシュヘッダーを追加

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,15 +8,20 @@ const nextConfig: NextConfig = {
     minimumCacheTTL: 31536000, // 1年間キャッシュ
   },
   async headers() {
+    const cacheHeaders = [
+      {
+        key: "Cache-Control",
+        value: "public, max-age=31536000, immutable",
+      },
+    ];
     return [
       {
         source: "/_next/image(.*)",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-        ],
+        headers: cacheHeaders,
+      },
+      {
+        source: "/images/poke-image(.*)",
+        headers: cacheHeaders,
       },
     ];
   },


### PR DESCRIPTION
## Summary

- `/images/poke-image(.*)` に `Cache-Control: public, max-age=31536000, immutable` を追加
- `/_next/image` と同一のキャッシュ設定（1年 immutable）を適用
- 共通のヘッダー定義を `cacheHeaders` 変数にまとめ、重複を排除

## Test plan

- [ ] `npm run build` が通ることを確認
- [ ] `/images/poke-image/` 配下のレスポンスヘッダーに `Cache-Control: public, max-age=31536000, immutable` が付いていることをDevToolsで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)