### PR TITLE
fix: ポケモン画像キャッシュヘッダーのパスを実ディレクトリに合わせる

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
         headers: cacheHeaders,
       },
       {
-        source: "/images/poke-image(.*)",
+        source: "/images/poke_image(.*)",
         headers: cacheHeaders,
       },
     ];


### PR DESCRIPTION
## Summary
- 直前PR #64 で追加した Cache-Control ヘッダーの `source` が `/images/poke-image(.*)`（ハイフン）になっていたが、実ディレクトリは `/public/images/poke_image/`（アンダースコア）でマッチしていなかった
- このため AvatarImage 等から参照される 495 枚のポケモン画像（約 13MB）に Cache-Control が付与されておらず、Vercel の edge request 浪費に繋がっていた可能性がある
- `source` をアンダースコア表記に修正

## Test plan
- [ ] デプロイ後に `curl -I https://nejiki-calculator.com/images/poke_image/poke0001.png` で `Cache-Control: public, max-age=31536000, immutable` が返ることを確認
- [ ] ブラウザ DevTools の Network タブで `/images/poke_image/*.png` のレスポンスヘッダーを確認
- [ ] Vercel ダッシュボードで edge request 数の推移を観測

🤖 Generated with [Claude Code](https://claude.com/claude-code)